### PR TITLE
Updating "types" valueIRI from biopurl to Interlex

### DIFF
--- a/DATS.json
+++ b/DATS.json
@@ -40,7 +40,7 @@
     {
       "information": {
 		"value": "MRI",
-        "valueIRI": "http://purl.bioontology.org/ontology/SNOMEDCT/113091000"
+		"valueIRI": "http://uri.interlex.org/ilx_0779748"
       }
     }
   ],


### PR DESCRIPTION
Following consultation with Brendan Behan this PR updates the valueIRI associated with the `types` field entry for `MRI`, from a biopurl link to an Interlex one, for consistency with our planned cross-reference functionality with CBRAIN.